### PR TITLE
Update .melange.yaml

### DIFF
--- a/.melange.yaml
+++ b/.melange.yaml
@@ -31,7 +31,7 @@ environment:
       - libxml2-dev
       - libxslt-dev
       - linux-headers
-      - openssl1.1-compat-dev
+      - openssl3-dev
       - pcre-dev
       - pkgconf
       - zeromq-dev


### PR DESCRIPTION
openssl package was out of date, the index shows openssl3 as latest and the build works.